### PR TITLE
Display admin review insights and fix user profile updates

### DIFF
--- a/src/app/api/user/[id]/route.js
+++ b/src/app/api/user/[id]/route.js
@@ -3,6 +3,64 @@ import { ObjectId } from "mongodb";
 
 export const runtime = "nodejs";
 
+const IMGBB_API_KEY = process.env.IMGBB_API_KEY;
+
+const sanitizeUser = (userDoc) => {
+  if (!userDoc) return null;
+
+  const imageUrl = userDoc.imageUrl || "";
+  const firstName = userDoc.firstName || "";
+  const lastName = userDoc.lastName || "";
+
+  return {
+    userId: userDoc._id?.toString?.() || userDoc._id,
+    firstName,
+    lastName,
+    name: `${firstName} ${lastName}`.trim(),
+    email: userDoc.email || "",
+    phone: userDoc.phone || "",
+    location: userDoc.location || "",
+    imageUrl,
+    avatar: imageUrl,
+    role: userDoc.role || "user",
+  };
+};
+
+const uploadAvatarToImgBB = async (file) => {
+  if (!file || typeof file.arrayBuffer !== "function") {
+    return null;
+  }
+
+  if (!IMGBB_API_KEY) {
+    throw new Error("ไม่พบค่า IMGBB_API_KEY ในระบบ");
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  const base64Image = Buffer.from(arrayBuffer).toString("base64");
+  const body = new URLSearchParams();
+  body.append("image", base64Image);
+
+  const response = await fetch(`https://api.imgbb.com/1/upload?key=${IMGBB_API_KEY}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    throw new Error("อัปโหลดรูปภาพไม่สำเร็จ");
+  }
+
+  const result = await response.json();
+  return result?.data?.url || null;
+};
+
+const getFormValue = (formData, key) => {
+  const value = formData.get(key);
+  if (value === null || typeof value === "undefined") return undefined;
+  if (typeof value === "string") return value.trim();
+  return value;
+};
+
 // PATCH: อัปเดตข้อมูลผู้ใช้ (เช่น role, name, email)
 export async function PATCH(req, { params }) {
   try {
@@ -48,5 +106,97 @@ export async function DELETE(req, { params }) {
   } catch (err) {
     console.error("Delete error:", err);
     return new Response(JSON.stringify({ message: "Internal Server Error" }), { status: 500 });
+  }
+}
+
+export async function PUT(req, { params }) {
+  try {
+    const { id } = params;
+
+    if (!ObjectId.isValid(id)) {
+      return new Response(JSON.stringify({ message: "รหัสผู้ใช้ไม่ถูกต้อง" }), { status: 400 });
+    }
+
+    const contentType = req.headers.get("content-type") || "";
+    const client = await clientPromise;
+    const db = client.db("myDB");
+    const users = db.collection("users");
+
+    let updatePayload = {};
+    let avatarFile = null;
+
+    if (contentType.includes("multipart/form-data")) {
+      const formData = await req.formData();
+      const firstName = getFormValue(formData, "firstName");
+      const lastName = getFormValue(formData, "lastName");
+      const email = getFormValue(formData, "email");
+      const phone = getFormValue(formData, "phone");
+      const location = getFormValue(formData, "location");
+      const imageUrl = getFormValue(formData, "imageUrl");
+      const avatar = formData.get("avatar");
+
+      updatePayload = {
+        ...(firstName !== undefined ? { firstName } : {}),
+        ...(lastName !== undefined ? { lastName } : {}),
+        ...(email !== undefined ? { email } : {}),
+        ...(phone !== undefined ? { phone } : {}),
+        ...(location !== undefined ? { location } : {}),
+      };
+
+      if (avatar && typeof avatar === "object" && "arrayBuffer" in avatar) {
+        avatarFile = avatar;
+      } else if (typeof imageUrl === "string" && imageUrl) {
+        updatePayload.imageUrl = imageUrl;
+      }
+    } else {
+      const body = await req.json();
+      updatePayload = { ...body };
+    }
+
+    if (Object.keys(updatePayload).length === 0 && !avatarFile) {
+      return new Response(JSON.stringify({ message: "ไม่มีข้อมูลที่ต้องการอัปเดต" }), { status: 400 });
+    }
+
+    if (avatarFile) {
+      const uploadedUrl = await uploadAvatarToImgBB(avatarFile);
+      if (uploadedUrl) {
+        updatePayload.imageUrl = uploadedUrl;
+      }
+    }
+
+    updatePayload.updatedAt = new Date();
+    if (updatePayload.firstName || updatePayload.lastName) {
+      const firstName = updatePayload.firstName ?? "";
+      const lastName = updatePayload.lastName ?? "";
+      updatePayload.name = `${firstName} ${lastName}`.trim();
+    }
+
+    const result = await users.findOneAndUpdate(
+      { _id: new ObjectId(id) },
+      { $set: updatePayload },
+      { returnDocument: "after", projection: { password: 0 } }
+    );
+
+    const updatedUser = result?.value ?? result;
+
+    if (!updatedUser) {
+      return new Response(JSON.stringify({ message: "ไม่พบข้อมูลผู้ใช้" }), { status: 404 });
+    }
+
+    const sanitized = sanitizeUser(updatedUser);
+
+    return new Response(
+      JSON.stringify({ message: "อัปเดตข้อมูลสำเร็จ", user: sanitized }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }
+    );
+  } catch (err) {
+    console.error("PUT /api/user/[id] error:", err);
+    return new Response(
+      JSON.stringify({ message: err.message || "เกิดข้อผิดพลาดภายในระบบ" }),
+      { status: 500 }
+    );
   }
 }

--- a/src/app/context/AuthContext.js
+++ b/src/app/context/AuthContext.js
@@ -6,24 +6,78 @@ export const AuthContext = createContext();
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null);
 
+  const normalizeId = (value) => {
+    if (!value) return "";
+    if (typeof value === "string") return value;
+    if (typeof value === "object") {
+      if (value.$oid) return value.$oid;
+      if (value.toString) return value.toString();
+    }
+    return String(value);
+  };
+
   useEffect(() => {
     const storedUser = localStorage.getItem("userData");
     if (storedUser) setUser(JSON.parse(storedUser));
   }, []);
 
+  const persistUser = (userData) => {
+    try {
+      if (!userData) {
+        localStorage.removeItem("userData");
+        return;
+      }
+
+      localStorage.setItem("userData", JSON.stringify(userData));
+    } catch (error) {
+      console.error("Persist user error:", error);
+    }
+  };
+
   const login = (userData) => {
-    if (!userData._id) console.warn("Missing _id in userData");
-    localStorage.setItem("userData", JSON.stringify(userData));
-    setUser(userData);
+    if (!userData?._id && !userData?.userId) {
+      console.warn("Missing user identifier in userData");
+    }
+
+    const normalizedUserId = normalizeId(userData?.userId || userData?._id);
+    const normalizedUser = {
+      ...userData,
+      userId: normalizedUserId || userData?.userId || userData?._id,
+    };
+
+    setUser(normalizedUser);
+    persistUser(normalizedUser);
   };
 
   const logout = () => {
-    localStorage.removeItem("userData");
+    persistUser(null);
     setUser(null);
   };
 
+  const updateUser = (updates) => {
+    setUser((prev) => {
+      const nextUserRaw =
+        typeof updates === "function"
+          ? updates(prev)
+          : { ...(prev || {}), ...updates };
+
+      if (!nextUserRaw) {
+        persistUser(null);
+        return null;
+      }
+
+      const nextUser = {
+        ...nextUserRaw,
+        userId: normalizeId(nextUserRaw.userId || nextUserRaw._id) || nextUserRaw.userId,
+      };
+
+      persistUser(nextUser);
+      return nextUser;
+    });
+  };
+
   return (
-    <AuthContext.Provider value={{ user, login, logout }}>
+    <AuthContext.Provider value={{ user, login, logout, updateUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/app/page/admin/history/page.js
+++ b/src/app/page/admin/history/page.js
@@ -3,6 +3,46 @@
 import React, { useState, useEffect } from 'react';
 import { Search, Eye, X, Star } from 'lucide-react';
 
+const normalizeId = (value) => {
+    if (!value) return '';
+    if (typeof value === 'string') return value;
+    if (typeof value === 'object') {
+        if (value.$oid) return value.$oid;
+        if (typeof value.toString === 'function') return value.toString();
+    }
+    return String(value);
+};
+
+const buildCustomerName = (userDetails = {}) => {
+    const firstName = userDetails.firstName || '';
+    const lastName = userDetails.lastName || '';
+    const fullName = `${firstName} ${lastName}`.trim();
+    return fullName || userDetails.name || userDetails.email || '-';
+};
+
+const mapBookingToHistoryJob = (booking) => {
+    const rating = booking?.rating ?? booking?.reviewDetail?.rating ?? 0;
+    const reviewComment = booking?.review ?? booking?.reviewDetail?.comment ?? '';
+    const priceValue = booking?.estimatedPrice ?? booking?.serviceDetails?.price ?? booking?.price ?? null;
+    const parsedPrice = typeof priceValue === 'number' ? priceValue : Number(priceValue) || 0;
+
+    return {
+        _id: normalizeId(booking?._id),
+        bookingId: normalizeId(booking?._id),
+        customerName: booking?.customerName || buildCustomerName(booking?.userDetails),
+        appointmentDate: booking?.bookingDate || booking?.completedDate || booking?.date || booking?.createdAt,
+        serviceType: booking?.serviceDetails?.serviceType || booking?.selectedOption || booking?.serviceName || '-',
+        price: parsedPrice,
+        status: booking?.status || 'completed',
+        address: booking?.customerLocation || booking?.address || booking?.serviceDetails?.location || '-',
+        phoneNumber: booking?.userDetails?.phone || booking?.phoneNumber || '-',
+        notes: booking?.notes || booking?.serviceDetails?.description || '',
+        rating: rating ? Number(rating) : 0,
+        feedback: reviewComment,
+        reviewedAt: booking?.reviewedAt || booking?.reviewDetail?.updatedAt || null,
+    };
+};
+
 const History = () => {
     const [searchTerm, setSearchTerm] = useState('');
     const [filterStatus, setFilterStatus] = useState('ทั้งหมด');
@@ -12,15 +52,40 @@ const History = () => {
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
 
- 
+    useEffect(() => {
+        const fetchHistoryJobs = async () => {
+            try {
+                setLoading(true);
+                setError(null);
+
+                const res = await fetch('/api/reviews');
+                const data = await res.json();
+
+                if (!res.ok) {
+                    throw new Error(data?.message || 'ไม่สามารถดึงข้อมูลรีวิวได้');
+                }
+
+                const bookings = Array.isArray(data?.data) ? data.data : [];
+                const mapped = bookings.map(mapBookingToHistoryJob);
+                setHistoryJobs(mapped);
+            } catch (err) {
+                console.error('fetchHistoryJobs error:', err);
+                setError(err.message || 'เกิดข้อผิดพลาดในการโหลดข้อมูล');
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchHistoryJobs();
+    }, []);
+
     const filteredJobs = historyJobs.filter(job => {
         const matchesSearch = job.customerName?.toLowerCase().includes(searchTerm.toLowerCase()) ||
                             job._id?.toLowerCase().includes(searchTerm.toLowerCase()) ||
                             job.serviceType?.toLowerCase().includes(searchTerm.toLowerCase());
-        
-        // Since we're only fetching accepted jobs, all jobs are "completed"
+
         const matchesFilter = filterStatus === 'ทั้งหมด' || filterStatus === 'เสร็จแล้ว';
-        
+
         return matchesSearch && matchesFilter;
     });
 
@@ -70,7 +135,9 @@ const History = () => {
     // Format price function
     const formatPrice = (price) => {
         if (!price) return '-';
-        return `${price.toLocaleString()} ฿`;
+        const numeric = typeof price === 'number' ? price : Number(price);
+        if (!Number.isFinite(numeric)) return '-';
+        return `${numeric.toLocaleString()} ฿`;
     };
 
     if (loading) {
@@ -143,6 +210,7 @@ const History = () => {
                                     <th className="text-left px-6 py-3 text-sm font-medium text-gray-500">ประเภทงาน</th>
                                     <th className="text-left px-6 py-3 text-sm font-medium text-gray-500">ราคารวม</th>
                                     <th className="text-left px-6 py-3 text-sm font-medium text-gray-500">สถานะ</th>
+                                    <th className="text-left px-6 py-3 text-sm font-medium text-gray-500">รีวิว</th>
                                     <th className="text-left px-6 py-3 text-sm font-medium text-gray-500">Action</th>
                                 </tr>
                             </thead>
@@ -157,8 +225,20 @@ const History = () => {
                                         <td className={`px-6 py-4 text-sm font-medium ${getStatusColor(job.status)}`}>
                                             {getStatusText(job.status)}
                                         </td>
+                                        <td className="px-6 py-4 text-sm text-gray-600">
+                                            {job.rating ? (
+                                                <div className="flex items-center space-x-2">
+                                                    <div className="flex items-center space-x-1">
+                                                        {renderStars(Math.round(job.rating))}
+                                                    </div>
+                                                    <span className="text-xs text-gray-500">{job.rating.toFixed(1)}/5</span>
+                                                </div>
+                                            ) : (
+                                                <span className="text-gray-400">ยังไม่มีรีวิว</span>
+                                            )}
+                                        </td>
                                         <td className="px-6 py-4 text-sm">
-                                            <button 
+                                            <button
                                                 onClick={() => handleViewJob(job)}
                                                 className="text-blue-600 hover:text-blue-800 flex items-center"
                                             >
@@ -193,7 +273,9 @@ const History = () => {
                     </div>
                     <div className="bg-white rounded-lg shadow-sm p-6 text-center">
                         <div className="text-2xl font-bold text-gray-800">
-                            {historyJobs.reduce((total, job) => total + (job.price || 0), 0).toLocaleString()}
+                            {historyJobs
+                                .reduce((total, job) => total + (Number(job.price) || 0), 0)
+                                .toLocaleString()}
                         </div>
                         <div className="text-sm text-gray-600">รายได้รวม (฿)</div>
                     </div>
@@ -266,24 +348,30 @@ const History = () => {
                             </div>
                         </div>
                         
-                        {/* Rating and Feedback Section */}
-                        {/* <div className="border-t pt-4">
-                            <div className="mb-3">
-                                <span className="text-sm text-gray-600">คะแนนความพึงพอใจ:</span>
-                                <div className="flex items-center mt-1">
-                                    {renderStars(selectedJob.rating)}
-                                    <span className="ml-2 text-sm text-gray-600">({selectedJob.rating || 0}/5)</span>
-                                </div>
-                            </div>
-                            {selectedJob.feedback && (
+                        {(selectedJob.rating || selectedJob.feedback) && (
+                            <div className="border-t pt-4 mt-4 space-y-3">
                                 <div>
-                                    <span className="text-sm text-gray-600">ความคิดเห็นจากลูกค้า:</span>
-                                    <p className="text-sm text-gray-800 mt-1 bg-gray-50 p-2 rounded">
-                                        {selectedJob.feedback}
-                                    </p>
+                                    <span className="text-sm text-gray-600">คะแนนความพึงพอใจ:</span>
+                                    <div className="flex items-center mt-1">
+                                        {renderStars(Math.round(selectedJob.rating || 0))}
+                                        <span className="ml-2 text-sm text-gray-600">({(selectedJob.rating || 0).toFixed(1)}/5)</span>
+                                    </div>
                                 </div>
-                            )}
-                        </div> */}
+                                {selectedJob.feedback && (
+                                    <div>
+                                        <span className="text-sm text-gray-600">ความคิดเห็นจากลูกค้า:</span>
+                                        <p className="text-sm text-gray-800 mt-1 bg-gray-50 p-2 rounded">
+                                            {selectedJob.feedback}
+                                        </p>
+                                    </div>
+                                )}
+                                {selectedJob.reviewedAt && (
+                                    <div className="text-xs text-gray-500">
+                                        อัปเดตล่าสุด: {formatDate(selectedJob.reviewedAt)}
+                                    </div>
+                                )}
+                            </div>
+                        )}
                     </div>
                 </div>
             )}


### PR DESCRIPTION
## Summary
- add a PUT handler for `/api/user/[id]` that normalizes updates, uploads optional avatars to ImgBB, and returns sanitized user data
- teach the auth context and user profile page to normalize user ids, send form data to the new endpoint, and persist updates in local storage
- load completed booking reviews on the admin history page and render ratings, feedback, and review timestamps for each job

## Testing
- not run (interactive `npm run lint` setup prompt)


------
https://chatgpt.com/codex/tasks/task_e_68cb86c3d41c832d843d49282a58ebe7