### PR TITLE
feat: add real-time booking notifications

### DIFF
--- a/src/app/api/notifications/[userId]/route.js
+++ b/src/app/api/notifications/[userId]/route.js
@@ -129,3 +129,34 @@ export async function PATCH(request, { params }) {
     );
   }
 }
+
+export async function DELETE(_request, { params }) {
+  try {
+    const { userId } = params;
+    const userFilter = buildUserFilter(userId);
+
+    if (!userFilter) {
+      return NextResponse.json(
+        { message: "รหัสผู้ใช้ไม่ถูกต้อง" },
+        { status: 400 }
+      );
+    }
+
+    const client = await clientPromise;
+    const db = client.db("myDB");
+    const collection = db.collection("notifications");
+
+    const result = await collection.deleteMany(userFilter);
+
+    return NextResponse.json({
+      message: "ลบการแจ้งเตือนเรียบร้อยแล้ว",
+      deletedCount: result.deletedCount,
+    });
+  } catch (error) {
+    console.error("Delete notifications error:", error);
+    return NextResponse.json(
+      { message: "ไม่สามารถลบการแจ้งเตือนได้" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/notifications/[userId]/route.js
+++ b/src/app/api/notifications/[userId]/route.js
@@ -1,0 +1,131 @@
+import clientPromise from "@/lib/mongodb";
+import { ObjectId } from "mongodb";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const toObjectId = (value) => {
+  if (!value) return null;
+  if (value instanceof ObjectId) return value;
+  if (typeof value === "string" && ObjectId.isValid(value)) {
+    return new ObjectId(value);
+  }
+  if (typeof value === "object" && value.$oid && ObjectId.isValid(value.$oid)) {
+    return new ObjectId(value.$oid);
+  }
+  return null;
+};
+
+const serializeNotification = (notification) => ({
+  ...notification,
+  _id: notification._id?.toString(),
+  userId: notification.userId?.toString?.() ?? notification.userId,
+  bookingId: notification.bookingId?.toString?.() ?? notification.bookingId,
+});
+
+const buildUserFilter = (userId) => {
+  const objectId = toObjectId(userId);
+
+  if (objectId) {
+    return {
+      $or: [
+        { userId: objectId },
+        { userId: userId },
+      ],
+    };
+  }
+
+  if (typeof userId === "string" && userId.trim() !== "") {
+    return { userId };
+  }
+
+  return null;
+};
+
+export async function GET(_req, { params }) {
+  try {
+    const { userId } = params;
+    const filter = buildUserFilter(userId);
+
+    if (!filter) {
+      return NextResponse.json(
+        { message: "รหัสผู้ใช้ไม่ถูกต้อง" },
+        { status: 400 }
+      );
+    }
+
+    const client = await clientPromise;
+    const db = client.db("myDB");
+    const notifications = await db
+      .collection("notifications")
+      .find(filter)
+      .sort({ createdAt: -1 })
+      .limit(50)
+      .toArray();
+
+    return NextResponse.json({
+      notifications: notifications.map(serializeNotification),
+    });
+  } catch (error) {
+    console.error("Fetch notifications error:", error);
+    return NextResponse.json(
+      { message: "ไม่สามารถดึงข้อมูลการแจ้งเตือนได้" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(request, { params }) {
+  try {
+    const { userId } = params;
+    const userFilter = buildUserFilter(userId);
+
+    if (!userFilter) {
+      return NextResponse.json(
+        { message: "รหัสผู้ใช้ไม่ถูกต้อง" },
+        { status: 400 }
+      );
+    }
+
+    let notificationIds = [];
+    try {
+      const body = await request.json();
+      notificationIds = Array.isArray(body?.notificationIds)
+        ? body.notificationIds
+        : [];
+    } catch (error) {
+      notificationIds = [];
+    }
+
+    const client = await clientPromise;
+    const db = client.db("myDB");
+    const collection = db.collection("notifications");
+
+    const filter = {
+      ...userFilter,
+      read: { $ne: true },
+    };
+    if (notificationIds.length > 0) {
+      filter._id = {
+        $in: notificationIds
+          .map((id) => toObjectId(id))
+          .filter((id) => id instanceof ObjectId),
+      };
+    }
+
+    await collection.updateMany(filter, {
+      $set: {
+        read: true,
+        readAt: new Date(),
+      },
+    });
+
+    return NextResponse.json({ message: "อัปเดตสถานะการแจ้งเตือนแล้ว" });
+  } catch (error) {
+    console.error("Update notifications error:", error);
+    return NextResponse.json(
+      { message: "ไม่สามารถอัปเดตการแจ้งเตือนได้" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/notifications/route.js
+++ b/src/app/api/notifications/route.js
@@ -1,0 +1,60 @@
+import clientPromise from "@/lib/mongodb";
+import { ObjectId } from "mongodb";
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const normalizeId = (value) => {
+  if (!value) return null;
+  if (ObjectId.isValid(value)) return new ObjectId(value);
+  if (typeof value === "object" && value.$oid && ObjectId.isValid(value.$oid)) {
+    return new ObjectId(value.$oid);
+  }
+  return value;
+};
+
+export async function POST(request) {
+  try {
+    const body = await request.json();
+    const { userId, bookingId, status, message } = body || {};
+
+    if (!userId || !bookingId || !status || !message) {
+      return NextResponse.json(
+        { message: "ข้อมูลไม่ครบถ้วน" },
+        { status: 400 }
+      );
+    }
+
+    const client = await clientPromise;
+    const db = client.db("myDB");
+    const notifications = db.collection("notifications");
+
+    const notificationDoc = {
+      userId: normalizeId(userId),
+      bookingId: normalizeId(bookingId),
+      status,
+      message,
+      read: false,
+      createdAt: new Date(),
+    };
+
+    const result = await notifications.insertOne(notificationDoc);
+
+    return NextResponse.json(
+      {
+        message: "บันทึกการแจ้งเตือนเรียบร้อย",
+        notification: {
+          ...notificationDoc,
+          _id: result.insertedId,
+        },
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("Create notification error:", error);
+    return NextResponse.json(
+      { message: "ไม่สามารถสร้างการแจ้งเตือนได้" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/components/navbar.js
+++ b/src/app/components/navbar.js
@@ -415,7 +415,7 @@ const Navbar = () => {
 
       {showAllNotifications && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+          className="fixed inset-0 z-50 backdrop-blur-sm flex items-center justify-center  bg-opacity-50"
           onClick={closeAllNotifications}
         >
           <div

--- a/src/app/components/navbar.js
+++ b/src/app/components/navbar.js
@@ -1,38 +1,133 @@
 "use client";
 import Link from "next/link";
 import Image from "next/image";
-import { useContext, useState } from "react";
+import { useContext, useEffect, useMemo, useState } from "react";
 import { AuthContext } from "../context/AuthContext";
 
 const Navbar = () => {
   const { user, logout } = useContext(AuthContext);
   const [showNotifications, setShowNotifications] = useState(false);
   const [showUserMenu, setShowUserMenu] = useState(false);
+  const [notifications, setNotifications] = useState([]);
+  const [notificationsError, setNotificationsError] = useState(null);
 
-  const notifications = [
-    {
-      id: 1,
-      message: "Function นี้ยังไม่พร้อมใช้งาน",
-      time: "Now",
-      isRead: false,
-    },
-    // {
-    //   id: 2,
-    //   message: "มีช่างเทคนิคกำลังเดินทางไปยังสถานที่ของคุณ",
-    //   time: "5 ชั่วโมงที่แล้ว",
-    //   isRead: false,
-    // },
-    // {
-    //   id: 3,
-    //   message: "งานซ่อมแซมเสร็จสิ้นแล้ว",
-    //   time: "1 วันที่แล้ว",
-    //   isRead: true,
-    // },
-  ];
+  const unreadCount = useMemo(
+    () => notifications.filter((notification) => !notification.read).length,
+    [notifications]
+  );
 
-  const toggleNotifications = () => {
-    setShowNotifications(!showNotifications);
+  const formatTimeAgo = (timestamp) => {
+    if (!timestamp) return "";
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) return "";
+
+    const diffMs = Date.now() - date.getTime();
+    if (diffMs < 60 * 1000) {
+      return "เมื่อสักครู่";
+    }
+
+    const diffMinutes = Math.floor(diffMs / (60 * 1000));
+    if (diffMinutes < 60) {
+      return `${diffMinutes} นาทีที่แล้ว`;
+    }
+
+    const diffHours = Math.floor(diffMinutes / 60);
+    if (diffHours < 24) {
+      return `${diffHours} ชั่วโมงที่แล้ว`;
+    }
+
+    const diffDays = Math.floor(diffHours / 24);
+    if (diffDays < 7) {
+      return `${diffDays} วันที่แล้ว`;
+    }
+
+    return date.toLocaleDateString("th-TH", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    });
+  };
+
+  useEffect(() => {
+    if (!user?.userId) {
+      setNotifications([]);
+      return;
+    }
+
+    let isMounted = true;
+    let isLoading = false;
+    let intervalId;
+
+    const fetchNotifications = async () => {
+      if (isLoading) return;
+      isLoading = true;
+      try {
+        setNotificationsError(null);
+        const res = await fetch(`/api/notifications/${user.userId}`);
+        if (!res.ok) {
+          throw new Error("ไม่สามารถดึงข้อมูลการแจ้งเตือนได้");
+        }
+        const data = await res.json();
+        const payload = Array.isArray(data)
+          ? data
+          : Array.isArray(data.notifications)
+          ? data.notifications
+          : [];
+
+        if (isMounted) {
+          setNotifications(payload);
+        }
+      } catch (error) {
+        if (isMounted) {
+          setNotificationsError(error.message);
+        }
+      } finally {
+        isLoading = false;
+      }
+    };
+
+    fetchNotifications();
+    intervalId = setInterval(fetchNotifications, 10000);
+
+    return () => {
+      isMounted = false;
+      if (intervalId) clearInterval(intervalId);
+    };
+  }, [user?.userId]);
+
+  const markNotificationsAsRead = async () => {
+    if (!user?.userId || notificationsError) return;
+    const unreadIds = notifications
+      .filter((notification) => !notification.read)
+      .map((notification) => notification._id)
+      .filter(Boolean);
+
+    if (unreadIds.length === 0) return;
+
+    try {
+      await fetch(`/api/notifications/${user.userId}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ notificationIds: unreadIds }),
+      });
+      setNotifications((prev) =>
+        prev.map((notification) => ({ ...notification, read: true }))
+      );
+    } catch (error) {
+      console.error("Failed to mark notifications as read:", error);
+    }
+  };
+
+  const toggleNotifications = async () => {
+    const nextState = !showNotifications;
+    setShowNotifications(nextState);
     setShowUserMenu(false);
+
+    if (nextState) {
+      await markNotificationsAsRead();
+    }
   };
 
   const toggleUserMenu = () => {
@@ -200,9 +295,9 @@ const Navbar = () => {
                       <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"></path>
                       <path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"></path>
                     </svg>
-                    {notifications.filter((n) => !n.isRead).length > 0 && (
+                    {unreadCount > 0 && (
                       <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full w-4 h-4 flex items-center justify-center">
-                        {notifications.filter((n) => !n.isRead).length}
+                        {unreadCount}
                       </span>
                     )}
                   </button>
@@ -215,30 +310,37 @@ const Navbar = () => {
                         </h3>
                       </div>
                       <div className="max-h-64 overflow-y-auto">
-                        {notifications.length > 0 ? (
-                          notifications.map((notification) => (
-                            <div
-                              key={notification.id}
-                              className={`p-3 border-b border-gray-100 hover:bg-gray-50 cursor-pointer ${
-                                !notification.isRead ? "bg-blue-50" : ""
-                              }`}
-                            >
-                              <p className="text-sm text-gray-800 mb-1">
-                                {notification.message}
-                              </p>
-                              <p className="text-xs text-gray-500">
-                                {notification.time}
-                              </p>
-                              {!notification.isRead && (
-                                <div className="w-2 h-2 bg-blue-500 rounded-full mt-1"></div>
-                              )}
-                            </div>
-                          ))
-                        ) : (
-                          <div className="p-4 text-center text-gray-500">
-                            ไม่มีการแจ้งเตือน
+                        {notificationsError && (
+                          <div className="p-4 text-center text-red-500 text-sm">
+                            {notificationsError}
                           </div>
                         )}
+                        {!notificationsError ? (
+                          notifications.length > 0 ? (
+                            notifications.map((notification) => (
+                              <div
+                                key={notification._id || notification.id}
+                                className={`p-3 border-b border-gray-100 hover:bg-gray-50 cursor-pointer ${
+                                  !notification.read ? "bg-blue-50" : ""
+                                }`}
+                              >
+                                <p className="text-sm text-gray-800 mb-1">
+                                  {notification.message || "มีการอัปเดตใหม่"}
+                                </p>
+                                <p className="text-xs text-gray-500">
+                                  {formatTimeAgo(notification.createdAt)}
+                                </p>
+                                {!notification.read && (
+                                  <div className="w-2 h-2 bg-blue-500 rounded-full mt-1"></div>
+                                )}
+                              </div>
+                            ))
+                          ) : (
+                            <div className="p-4 text-center text-gray-500">
+                              ไม่มีการแจ้งเตือน
+                            </div>
+                          )
+                        ) : null}
                       </div>
                       <div className="p-3 border-t border-gray-200 text-center">
                         <button className="text-sm text-blue-600 hover:text-blue-800">


### PR DESCRIPTION
## Summary
- add dedicated notification APIs for persisting booking status updates
- trigger notification creation when admins change booking statuses
- fetch and display live notifications in the navbar with polling and read tracking

## Testing
- not run (next lint prompts for interactive configuration)


------
https://chatgpt.com/codex/tasks/task_e_68cbafea7794832db095446826a0a368