### PR TITLE
Switch service checkout to PromptPay QR workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,14 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## PromptPay QR configuration
+
+Set the PromptPay number that should appear in the checkout QR code via the `NEXT_PUBLIC_PROMPTPAY_NUMBER` environment variable.
+For example, add the following to your `.env.local` file:
+
+```
+NEXT_PUBLIC_PROMPTPAY_NUMBER=0812345678
+```
+
+When a customer scans the QR code and uploads their payment slip, the booking will be created and the slip stored for review.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['i.ibb.co'],
+    domains: ['i.ibb.co', 'chart.googleapis.com'],
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "home-service",
       "version": "0.1.0",
       "dependencies": {
-        "@stripe/stripe-js": "^7.6.1",
         "axios": "^1.10.0",
         "bcryptjs": "^3.0.2",
         "dotenv": "^17.0.0",
@@ -19,8 +18,7 @@
         "next": "^15.3.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-hot-toast": "^2.5.2",
-        "stripe": "^18.3.0"
+        "react-hot-toast": "^2.5.2"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -689,15 +687,6 @@
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.1.5"
-      }
-    },
-    "node_modules/@stripe/stripe-js": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.6.1.tgz",
-      "integrity": "sha512-BUDj5gujbtx53/Cexws0+aPrEBsKAN8ExPf9UfuTCivVU6ug2PjqI0zUeL1jon3795eOLlyqvCDjp6VNknjE0A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.16"
       }
     },
     "node_modules/@swc/counter": {
@@ -2500,26 +2489,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/stripe": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.3.0.tgz",
-      "integrity": "sha512-FkxrTUUcWB4CVN2yzgsfF/YHD6WgYHduaa7VmokCy5TLCgl5UNJkwortxcedrxSavQ8Qfa4Ir4JxcbIYiBsyLg==",
-      "license": "MIT",
-      "dependencies": {
-        "qs": "^6.11.0"
-      },
-      "engines": {
-        "node": ">=12.*"
-      },
-      "peerDependencies": {
-        "@types/node": ">=12.x.x"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
       }
     },
     "node_modules/styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@stripe/stripe-js": "^7.6.1",
     "axios": "^1.10.0",
     "bcryptjs": "^3.0.2",
     "dotenv": "^17.0.0",
@@ -20,8 +19,7 @@
     "next": "^15.3.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-hot-toast": "^2.5.2",
-    "stripe": "^18.3.0"
+    "react-hot-toast": "^2.5.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
- replace the service booking checkout modal with a PromptPay QR experience that requires slip uploads before confirming payment
- store PromptPay payment metadata on the backend instead of creating Stripe checkout sessions
- drop Stripe dependencies and document the NEXT_PUBLIC_PROMPTPAY_NUMBER environment requirement

## Testing
- npm run lint *(fails: requires interactive configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68e4be242f34832d99a026f51c200700