### PR TITLE
Handle missing MongoDB URI environment variable

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,6 +4,13 @@ require("dotenv").config()
 
 const uri = process.env.MONGODB_URI
 
+if (!uri) {
+  console.error(
+    "❌ Missing MONGODB_URI environment variable. Please define it in your .env file."
+  )
+  process.exit(1)
+}
+
 async function testConnection() {
   const client = new MongoClient(uri)
 


### PR DESCRIPTION
## Summary
- fail fast when the MongoDB connection string environment variable is absent

## Testing
- node server.js

------
https://chatgpt.com/codex/tasks/task_e_68e4fbd27758832d8860b03b4bf8cb78