### PR TITLE
Require admin to upload completion photos before closing jobs

### DIFF
--- a/src/app/api/reviews/route.js
+++ b/src/app/api/reviews/route.js
@@ -104,6 +104,8 @@ export async function GET(req) {
           time: 1,
           address: 1,
           customerLocation: 1,
+          completionPhotos: 1,
+          completedAt: 1,
           rating: 1,
           review: 1,
           reviewDetail: 1,


### PR DESCRIPTION
## Summary
- require admins to upload and preview at least three after-service photos before marking a booking complete, including form validation and better popup UX
- validate and store completion photos plus completion timestamps in the booking PATCH API to enforce the new rule
- expose completion photos in the reviews API and display thumbnails and full galleries on the user review page for transparency

## Testing
- npm run lint *(fails: command prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d6807b18832dbc671507a2536514